### PR TITLE
Update Src/System.Linq.Dynamic/DynamicLinq.cs

### DIFF
--- a/Src/System.Linq.Dynamic/DynamicLinq.cs
+++ b/Src/System.Linq.Dynamic/DynamicLinq.cs
@@ -523,6 +523,8 @@ namespace System.Linq.Dynamic
         {
             void F(bool x, bool y);
             void F(bool? x, bool? y);
+            void F(Guid x, Guid y);
+            void F(Guid? x, Guid? y);
         }
 
         interface IAddSignatures : IArithmeticSignatures


### PR DESCRIPTION
Update to allow Guid comparison.

https://connect.microsoft.com/VisualStudio/feedback/details/333262/system-linq-dynamic-throws-an-error-when-using-guid-equality-in-where-clause
