### PR TITLE
BugFix: #77 Aggregate method does not work with Average function

### DIFF
--- a/Src/System.Linq.Dynamic.Test/DynamicQueryableTests.cs
+++ b/Src/System.Linq.Dynamic.Test/DynamicQueryableTests.cs
@@ -1,0 +1,82 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+/**
+ * This class is copied and customized from:
+ * https://github.com/StefH/System.Linq.Dynamic.Core/blob/master/test/System.Linq.Dynamic.Core.Tests/QueryableTests.Aggregate.cs
+ */
+
+namespace System.Linq.Dynamic.Test
+{
+    [TestClass]
+    public class DynamicQueryableTests
+    {
+        [TestMethod]
+        public void Aggregate_Average()
+        {
+            // Arrange
+            var queryable = new[]
+            {
+                new AggregateTest { Double = 50, Float = 1.0f, Int = 42, NullableDouble = 400, NullableFloat = 100f, NullableInt = 60 },
+                new AggregateTest { Double = 0, Float = 0.0f, Int = 0, NullableDouble = 0, NullableFloat = 0, NullableInt = 0 }
+            }.AsQueryable();
+
+            // Act
+            var resultNullableFloat = queryable.Aggregate("Average", "NullableFloat");
+            var resultFloat = queryable.Aggregate("Average", "Float");
+            var resultDouble = queryable.Aggregate("Average", "Double");
+            var resultNullableDouble = queryable.Aggregate("Average", "NullableDouble");
+            var resultInt = queryable.Aggregate("Average", "Int");
+            var resultNullableInt = queryable.Aggregate("Average", "NullableInt");
+
+            // Assert
+            Assert.AreEqual(50f, resultNullableFloat);
+            Assert.AreEqual(200.0, resultNullableDouble);
+            Assert.AreEqual(25.0, resultDouble);
+            Assert.AreEqual(0.5f, resultFloat);
+            Assert.AreEqual(21.0, resultInt);
+            Assert.AreEqual(30.0, resultNullableInt);
+        }
+
+        [TestMethod]
+        public void Aggregate_Min()
+        {
+            // Arrange
+            var queryable = new[]
+            {
+                new AggregateTest { Double = 50, Float = 1.0f, Int = 42, NullableDouble = 400, NullableFloat = 100f, NullableInt = 60 },
+                new AggregateTest { Double = 51, Float = 2.0f, Int = 90, NullableDouble = 800, NullableFloat = 101f, NullableInt = 61 }
+            }.AsQueryable();
+
+            // Act
+            var resultDouble = queryable.Aggregate("Min", "Double");
+            var resultFloat = queryable.Aggregate("Min", "Float");
+            var resultInt = queryable.Aggregate("Min", "Int");
+            var resultNullableDouble = queryable.Aggregate("Min", "NullableDouble");
+            var resultNullableFloat = queryable.Aggregate("Min", "NullableFloat");
+            var resultNullableInt = queryable.Aggregate("Min", "NullableInt");
+
+            // Assert
+            Assert.AreEqual(50.0, resultDouble);
+            Assert.AreEqual(1.0f, resultFloat);
+            Assert.AreEqual(42, resultInt);
+            Assert.AreEqual(400.0, resultNullableDouble);
+            Assert.AreEqual(100f, resultNullableFloat);
+            Assert.AreEqual(60, resultNullableInt);
+        }
+
+        internal class AggregateTest
+        {
+            public double Double { get; set; }
+
+            public double? NullableDouble { get; set; }
+
+            public float Float { get; set; }
+
+            public float? NullableFloat { get; set; }
+
+            public int Int { get; set; }
+
+            public int? NullableInt { get; set; }
+        }
+    }
+}

--- a/Src/System.Linq.Dynamic.Test/System.Linq.Dynamic.Test.csproj
+++ b/Src/System.Linq.Dynamic.Test/System.Linq.Dynamic.Test.csproj
@@ -46,6 +46,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="DynamicExpressionCultureTests.cs" />
+    <Compile Include="DynamicQueryableTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="DynamicExpressionTests.cs" />
   </ItemGroup>

--- a/Src/System.Linq.Dynamic/DynamicLinq.cs
+++ b/Src/System.Linq.Dynamic/DynamicLinq.cs
@@ -155,10 +155,10 @@ namespace System.Linq.Dynamic
             // We've tried to find an expression of the type Expression<Func<TSource, TAcc>>,
             // which is expressed as ( (TSource s) => s.Price );
 
-            var methods = typeof(Queryable).GetMethods().Where(x => x.Name == function && m.IsGenericMethod);
+            var methods = typeof(Queryable).GetMethods().Where(x => x.Name == function && x.IsGenericMethod);
 
             // Method
-	    MethodInfo aggregateMethod = methods.SingleOrDefault(m =>
+            MethodInfo aggregateMethod = methods.SingleOrDefault(m =>
             {
                 ParameterInfo lastParameter = m.GetParameters().LastOrDefault();
                 if (lastParameter != null)
@@ -191,8 +191,8 @@ namespace System.Linq.Dynamic
                         new[] { source.Expression, Expression.Quote(selector) }));
             }
         }
-	 
-	private static Type GetRightOuterType(Type type)
+      
+        private static Type GetRightOuterType(Type type)
         {
             if (type != null)
             {
@@ -455,7 +455,7 @@ namespace System.Linq.Dynamic
                 if (!classes.TryGetValue(signature, out type))
                 {
                     type = CreateAndCacheDynamicClass(signature);
-                    
+
                 }
                 return type;
             }
@@ -799,7 +799,7 @@ namespace System.Linq.Dynamic
             typeof(Guid),
             typeof(Math),
             typeof(Convert),
-			typeof(System.Data.Objects.EntityFunctions)
+            typeof(System.Data.Objects.EntityFunctions)
         };
 
         static readonly Expression trueLiteral = Expression.Constant(true);
@@ -1543,7 +1543,7 @@ namespace System.Linq.Dynamic
             {
                 args = new Expression[] { instance };
             }
-            
+
 
             else
             {


### PR DESCRIPTION
Fixes the problem, that 'Average' function does not work when input field type is not equal return type in the Aggregate method.