### PR TITLE
Alternative fix for #80

### DIFF
--- a/Src/System.Linq.Dynamic.Test/MemberSearchTests.cs
+++ b/Src/System.Linq.Dynamic.Test/MemberSearchTests.cs
@@ -1,0 +1,112 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace System.Linq.Dynamic.Test
+{
+    [TestClass]
+    public class MemberSearchTests
+    {
+        [TestMethod]
+        public void MemberSearch_ClassMemberPriority()
+        {
+            var expression = DynamicExpression.ParseLambda(
+                new[] { Expression.Parameter(typeof(EnumerableClassWithConflictMembers), "") },
+                typeof(bool),
+                "it.Any()");
+            var result = expression.Compile().DynamicInvoke(new EnumerableClassWithConflictMembers());
+
+            Assert.AreEqual(false, result);
+        }
+
+        [TestMethod]
+        public void MemberSearch_ClassMemberPriority_ArgumentContext()
+        {
+            var expression = DynamicExpression.ParseLambda(
+                new[] { Expression.Parameter(typeof(EnumerableClassWithConflictMembers), "") },
+                typeof(int),
+                "it.Sum(val)");
+            var result = expression.Compile().DynamicInvoke(new EnumerableClassWithConflictMembers());
+
+            Assert.AreEqual(90, result);
+        }
+
+        [TestMethod]
+        public void MemberSearch_AggregateFunction()
+        {
+            var expression = DynamicExpression.ParseLambda(
+                new[] { Expression.Parameter(typeof(EnumerableClassWithoutConflictMembers), "") },
+                typeof(bool),
+                "it.Any()", new EnumerableClassWithoutConflictMembers());
+            var result = expression.Compile().DynamicInvoke(new EnumerableClassWithoutConflictMembers());
+
+            Assert.AreEqual(true, result);
+        }
+
+        [TestMethod]
+        public void MemberSearch_AggregateFunction_ArgumentContext()
+        {
+            var expression = DynamicExpression.ParseLambda(
+                new[] { Expression.Parameter(typeof(EnumerableClassWithoutConflictMembers), "") },
+                typeof(int),
+                "it.Sum(val)");
+            var result = expression.Compile().DynamicInvoke(new EnumerableClassWithoutConflictMembers());
+
+            Assert.AreEqual(6, result);
+        }
+
+        [TestMethod]
+        public void MemberSearch_AggregateFunction_ArgumentContext_WithoutIt()
+        {
+            var expression = DynamicExpression.ParseLambda(
+                new[] { Expression.Parameter(typeof(EnumerableClassWithoutConflictMembers), "x") },
+                typeof(int),
+                "x.Sum(val)");
+            var result = expression.Compile().DynamicInvoke(new EnumerableClassWithoutConflictMembers());
+
+            Assert.AreEqual(6, result);
+        }
+
+        private class EnumerableClassWithoutConflictMembers : IEnumerable<SimpleObject>
+        {
+            public int val = 88;
+
+            public IEnumerator<SimpleObject> GetEnumerator()
+            {
+                yield return new SimpleObject(1);
+                yield return new SimpleObject(2);
+                yield return new SimpleObject(3);
+            }
+
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        }
+
+        private class EnumerableClassWithConflictMembers : IEnumerable<SimpleObject>
+        {
+            public int val = 88;
+
+            public bool Any() => false;
+            public int Sum(int input) => input + 2;
+
+            public IEnumerator<SimpleObject> GetEnumerator()
+            {
+                yield return new SimpleObject(1);
+                yield return new SimpleObject(2);
+                yield return new SimpleObject(3);
+            }
+
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        }
+
+        private class SimpleObject
+        {
+            public int val;
+
+            public SimpleObject(int value)
+            {
+                val = value;
+            }
+        }
+    }
+}

--- a/Src/System.Linq.Dynamic.Test/System.Linq.Dynamic.Test.csproj
+++ b/Src/System.Linq.Dynamic.Test/System.Linq.Dynamic.Test.csproj
@@ -46,6 +46,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="DynamicExpressionCultureTests.cs" />
+    <Compile Include="MemberSearchTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="DynamicExpressionTests.cs" />
   </ItemGroup>

--- a/Src/System.Linq.Dynamic/DynamicLinq.cs
+++ b/Src/System.Linq.Dynamic/DynamicLinq.cs
@@ -1450,14 +1450,16 @@ namespace System.Linq.Dynamic
             {
                 int beforeArgumentListPos = textPos;
                 var beforeArgumentListToken = token;
+                Exception argumentListParseException = null;
                 Expression[] args;
                 try
                 {
                     args = ParseArgumentList();
                 }
-                catch
+                catch(Exception x)
                 {
                     args = null;
+                    argumentListParseException = x;
                 }
                 MethodBase mb = null;
                 switch (args != null ? FindMethod(type, id, instance == null, args, out mb) : 0)
@@ -1474,6 +1476,9 @@ namespace System.Linq.Dynamic
                                 return ParseAggregate(instance, elementType, id, errorPos);
                             }
                         }
+
+                        if (argumentListParseException != null)
+                            throw argumentListParseException;
 
                         throw ParseError(errorPos, Res.NoApplicableMethod,
                             id, GetTypeName(type));

--- a/Src/System.Linq.Dynamic/DynamicLinq.cs
+++ b/Src/System.Linq.Dynamic/DynamicLinq.cs
@@ -1448,20 +1448,25 @@ namespace System.Linq.Dynamic
             NextToken();
             if (token.id == TokenId.OpenParen)
             {
-                if (instance != null && type != typeof(string))
-                {
-                    Type enumerableType = FindGenericType(typeof(IEnumerable<>), type);
-                    if (enumerableType != null)
-                    {
-                        Type elementType = enumerableType.GetGenericArguments()[0];
-                        return ParseAggregate(instance, elementType, id, errorPos);
-                    }
-                }
+                int beforeArgumentListPos = textPos;
+                var beforeArgumentListToken = token;
                 Expression[] args = ParseArgumentList();
                 MethodBase mb;
                 switch (FindMethod(type, id, instance == null, args, out mb))
                 {
                     case 0:
+                        if (instance != null && type != typeof(string))
+                        {
+                            Type enumerableType = FindGenericType(typeof(IEnumerable<>), type);
+                            if (enumerableType != null)
+                            {
+                                Type elementType = enumerableType.GetGenericArguments()[0];
+                                SetTextPos(beforeArgumentListPos);
+                                token = beforeArgumentListToken;
+                                return ParseAggregate(instance, elementType, id, errorPos);
+                            }
+                        }
+
                         throw ParseError(errorPos, Res.NoApplicableMethod,
                             id, GetTypeName(type));
                     case 1:

--- a/Src/System.Linq.Dynamic/DynamicLinq.cs
+++ b/Src/System.Linq.Dynamic/DynamicLinq.cs
@@ -1450,9 +1450,17 @@ namespace System.Linq.Dynamic
             {
                 int beforeArgumentListPos = textPos;
                 var beforeArgumentListToken = token;
-                Expression[] args = ParseArgumentList();
-                MethodBase mb;
-                switch (FindMethod(type, id, instance == null, args, out mb))
+                Expression[] args;
+                try
+                {
+                    args = ParseArgumentList();
+                }
+                catch
+                {
+                    args = null;
+                }
+                MethodBase mb = null;
+                switch (args != null ? FindMethod(type, id, instance == null, args, out mb) : 0)
                 {
                     case 0:
                         if (instance != null && type != typeof(string))


### PR DESCRIPTION
This is an alternative to the fix for #80 proposed by @ricfwolff, which also prioritises instance members over the built in 'known' aggregate functions. Also adds a set of unit tests to verify the behaviour.

It also addresses another problem with @ricfwolff's solution which is that the argument list must be parsed in a different context depending on whether we're treating it as a instance method or an aggregate function (`it` is different).

Unfortunately since we don't know in advance which case it is, and `it` is different for each case, arguments that are perfectly valid for use in an aggregate function may be invalid and throw an exception when being parsed in the context of an instance method.

I can't see way around this that doesn't involve _huge_ changes (e.g. a way for ParseArgumentList() to return success state rather than throwing on error), other than just using a try/catch.

Open to suggestions for alternatives.