### PR TITLE
array() and dictionary() calls added

### DIFF
--- a/NuGet/rgdev_System.Linq.Dynamic.1.0.8.nuspec
+++ b/NuGet/rgdev_System.Linq.Dynamic.1.0.8.nuspec
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
+  <metadata>
+    <id>rgdev_System.Linq.Dynamic</id>
+    <version>1.0.8</version>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <licenseUrl>http://www.opensource.org/licenses/ms-pl</licenseUrl>
+    <projectUrl>https://github.com/kahanu/System.Linq.Dynamic</projectUrl>
+    <description>This is the Microsoft assembly for the .Net 4.0 Dynamic language functionality.</description>
+    <releaseNotes>lafar6502/System.Linq.Dynamic build
+contains some modifications not merged yet into the original repo kahanu</releaseNotes>
+    <tags>system linq dynamic</tags>
+  </metadata>
+  <files>
+    <file src="lib\net40\System.Linq.Dynamic.dll" target="lib\net40\System.Linq.Dynamic.dll" />
+    <file src="lib\net40\System.Linq.Dynamic.pdb" target="lib\net40\System.Linq.Dynamic.pdb" />
+  </files>
+</package>

--- a/Src/System.Linq.Dynamic.Test/DynamicExpressionTests.cs
+++ b/Src/System.Linq.Dynamic.Test/DynamicExpressionTests.cs
@@ -43,6 +43,53 @@ namespace System.Linq.Dynamic.Test
         }
 
         [TestMethod]
+        public void ParseLambda_NewArrayInit()
+        {
+            DateTime dt = DateTime.Now;
+            
+            var expr = DynamicExpression.ParseLambda(
+                typeof(Func<DateTime, object[]>),
+                new []
+                {
+                    Expression.Parameter(typeof(DateTime), "dt")
+                },
+                null,
+                "array(dt.Year, dt.Month, 15, \"ala ma kota\", dt.Ticks, dt.Date.Ticks)"
+                );
+
+
+            Assert.AreEqual(typeof(object[]), expr.ReturnType);
+            Assert.AreEqual(typeof(Func<DateTime, object[]>), expr.Type);
+            var texpr = (Expression<Func<DateTime, object[]>>)expr;
+            var fun = texpr.Compile();
+            var res = fun(dt);
+        }
+
+        [TestMethod]
+        public void ParseLambda_NewDictionary()
+        {
+            //this does not work - didnt figure oout how to make useful lambda with dictionary initialization
+            DateTime dt = DateTime.Now;
+
+            var expr = DynamicExpression.ParseLambda(
+                typeof(Func<DateTime, Dictionary<string, object>>),
+                new[]
+                {
+                    Expression.Parameter(typeof(DateTime), "dt")
+                },
+                typeof(Dictionary<string, object>),
+                "dictionary(dt.Year as y, dt.Month as m, 15 as fifteen, \"ala ma kota\" as text, dt.Ticks, dt.Date.Ticks as rounded_ticks)"
+                );
+
+
+            Assert.AreEqual(typeof(Dictionary<string, object>), expr.ReturnType);
+            Assert.AreEqual(typeof(Func<DateTime, Dictionary<string, object>>), expr.Type);
+            var texpr = (Expression<Func<DateTime, Dictionary<string, object>>>)expr;
+            var fun = texpr.Compile();
+            var res = fun(dt);
+        }
+
+        [TestMethod]
         public void ParseLambda_VoidMethodCall_ReturnsActionDelegate()
         {
             var expression = DynamicExpression.ParseLambda(
@@ -52,6 +99,7 @@ namespace System.Linq.Dynamic.Test
             Assert.AreEqual(typeof(void), expression.ReturnType);
             Assert.AreEqual(typeof(Action<System.IO.FileStream>), expression.Type);
         }
+
 
         [TestMethod]
         public void CreateClass_TheadSafe()


### PR DESCRIPTION
Possibility to parse lambdas with array and dictionary initializers

array(Value1, Value2, ...) => returns object[]

dictionary(m.Something as key1, Value2 as key2, ...) => returns Dictionary<string, object>

