### PR TITLE
Reinstate type whitelist check on method invocations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ Src/System.Linq.Dynamic.sln.DotSettings.user
 *.nupkg
 *.dll
 Src/TestResults/
+/Src/.vs/System.Linq.Dynamic/v15/Server/sqlite3

--- a/Src/System.Linq.Dynamic.Test/DynamicExpressionTests.cs
+++ b/Src/System.Linq.Dynamic.Test/DynamicExpressionTests.cs
@@ -24,7 +24,8 @@ namespace System.Linq.Dynamic.Test
             var expression = DynamicExpression.ParseLambda(
                 typeof(Tuple<int>),
                 typeof(string),
-                "it.ToString()");
+                "it.ToString()",
+                typeof(Tuple<int>));
             Assert.AreEqual(typeof(string), expression.ReturnType);
         }
 
@@ -48,9 +49,20 @@ namespace System.Linq.Dynamic.Test
             var expression = DynamicExpression.ParseLambda(
                 typeof(System.IO.FileStream),
                 null,
-                "it.Close()");
+                "it.Close()",
+                typeof(System.IO.FileStream));
             Assert.AreEqual(typeof(void), expression.ReturnType);
             Assert.AreEqual(typeof(Action<System.IO.FileStream>), expression.Type);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ParseException))]
+        public void ParseLambda_NonWhitelistedMethodCall_ThrowsParseException()
+        {
+            DynamicExpression.ParseLambda(
+                typeof(Reflection.Assembly),
+                typeof(Type[]),
+                "it.GetTypes()");
         }
 
         [TestMethod]

--- a/Src/System.Linq.Dynamic/DynamicLinq.cs
+++ b/Src/System.Linq.Dynamic/DynamicLinq.cs
@@ -780,7 +780,7 @@ namespace System.Linq.Dynamic
             typeof(Guid),
             typeof(Math),
             typeof(Convert),
-			typeof(System.Data.Objects.EntityFunctions)
+            typeof(System.Data.Objects.EntityFunctions)
         };
 
         static readonly Expression trueLiteral = Expression.Constant(true);
@@ -1465,7 +1465,10 @@ namespace System.Linq.Dynamic
                         throw ParseError(errorPos, Res.NoApplicableMethod,
                             id, GetTypeName(type));
                     case 1:
-                        return Expression.Call(instance, (MethodInfo)mb, args);
+                        MethodInfo method = (MethodInfo)mb;
+                        if (!IsWhitelistedType(method.DeclaringType))
+                            throw ParseError(errorPos, Res.MethodsAreInaccessible, GetTypeName(method.DeclaringType));
+                        return Expression.Call(instance, method, args);
                     default:
                         throw ParseError(errorPos, Res.AmbiguousMethodInvocation,
                             id, GetTypeName(type));
@@ -1591,6 +1594,11 @@ namespace System.Linq.Dynamic
                             GetTypeName(expr.Type));
                 }
             }
+        }
+
+        bool IsWhitelistedType(Type type)
+        {
+            return predefinedTypes.Contains(type);
         }
 
         static bool IsNullableType(Type type)


### PR DESCRIPTION
This pull request fixes #62 by reinstating the type whitelist checks on all method invocations. Flexibility of the dynamic LINQ lambda expression parser has been retained by allowing extra whitelist types to be declared via the `values` parameter to `ParseLambda`.

Regression tests have been updated to prevent the issue from resurfacing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kahanu/system.linq.dynamic/100)
<!-- Reviewable:end -->
